### PR TITLE
Fully support relative assembly paths in CLI

### DIFF
--- a/Dashing.Cli/Commands/Migrate.cs
+++ b/Dashing.Cli/Commands/Migrate.cs
@@ -31,7 +31,7 @@
                     c.OnExecute(
                         () => {
                             c.EnableLogging();
-                            var assemblyDir = Path.GetDirectoryName(assemblyPath.Value());
+                            var assemblyDir = Path.GetDirectoryName(Path.GetFullPath(assemblyPath.Value()));
                             Program.AssemblySearchDirectories.Insert(0, assemblyDir); // favour user code over dashing code
                             ScriptExtensions.DisplayMigrationHeader(assemblyPath.Value(), configurationType.Value(), connectionString.Value());
                             try {

--- a/Dashing.Cli/Commands/Script.cs
+++ b/Dashing.Cli/Commands/Script.cs
@@ -28,7 +28,7 @@
                     c.OnExecute(
                         () => {
                             c.EnableLogging();
-                            var assemblyDir = Path.GetDirectoryName(assemblyPath.Value());
+                            var assemblyDir = Path.GetDirectoryName(Path.GetFullPath(assemblyPath.Value()));
                             Program.AssemblySearchDirectories.Insert(0, assemblyDir); // favour user code over dashing code
                             ScriptExtensions.DisplayMigrationHeader(assemblyPath.Value(), configurationType.Value(), connectionString.Value());
                             try

--- a/Dashing.Cli/Commands/Seed.cs
+++ b/Dashing.Cli/Commands/Seed.cs
@@ -31,7 +31,7 @@
                     c.OnExecute(
                         () => {
                             c.EnableLogging();
-                            var assemblyDir = Path.GetDirectoryName(configurationAssemblyPath.Value());
+                            var assemblyDir = Path.GetDirectoryName(Path.GetFullPath(configurationAssemblyPath.Value()));
                             Program.AssemblySearchDirectories.Insert(0, assemblyDir); // favour user code over dashing code
                             try {
                                 ExecuteSeed(seederAssemblyPath, seederType, configurationAssemblyPath, configurationType, connectionString, provider);


### PR DESCRIPTION
Reproduction
Run dotnet-dashing with a relative assembly path